### PR TITLE
Add logging and timeout to self-play loop

### DIFF
--- a/training_pipeline.py
+++ b/training_pipeline.py
@@ -36,7 +36,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 REPLAY_BUFFER_SIZE = 250000
 BATCH_SIZE = 64
 LEARNING_RATE = 0.001
-NUM_SIMULATIONS = 200  # Reduced for debugging
+NUM_SIMULATIONS = 20  # Reduced for faster debugging
 TURNS_UNTIL_GREEDY = 10
 NUM_EVAL_GAMES = 20
 WIN_RATE_THRESHOLD = 0.55
@@ -72,10 +72,19 @@ def run_self_play_game(network_weights):
 
         game = ScrabbleGame(player_names=["LexiZero_A", "LexiZero_B"], gaddag=worker_gaddag)
         game_history = []
-        
+
+        start_time = time.time()
+        TIMEOUT_SECONDS = 60
+
         # This loop now correctly wraps the game logic
         for turn_count in range(1, MAX_GAME_TURNS + 1):
-            
+            elapsed = time.time() - start_time
+            print(f"Worker {os.getpid()}: Turn {turn_count}, elapsed {elapsed:.1f}s")
+
+            if elapsed > TIMEOUT_SECONDS:
+                print(f"Worker {os.getpid()}: Timeout reached, ending game early.")
+                break
+
             if game.is_game_over():
                 break
 


### PR DESCRIPTION
## Summary
- Show self-play progress and stop games that run too long
- Reduce simulation count for faster debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adff8acd908324b9985c7cda9ffab4