### PR TITLE
Limit move generation during self-play

### DIFF
--- a/pomcts.py
+++ b/pomcts.py
@@ -13,6 +13,7 @@ from state_encoder import encode_state
 
 # --- Constants ---
 C_PUCT = 1.0
+MAX_LEGAL_MOVES = 500
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ def pomcts_search(game: ScrabbleGame, network: LexiZeroNet, gaddag: Gaddag, num_
             
             rack = determinized_world.get_current_player().rack
             board = determinized_world.board
-            legal_moves = gaddag.find_moves(rack, board)
+            legal_moves = gaddag.find_moves(rack, board, max_moves=MAX_LEGAL_MOVES)
 
             if determinized_world.bag.get_remaining_count() >= len(rack):
                 rack_letters = "".join(sorted([tile.letter for tile in rack]))

--- a/test_scrabble.py
+++ b/test_scrabble.py
@@ -181,7 +181,7 @@ class TestGaddag(unittest.TestCase):
     def test_find_moves_simple(self):
         """Test finding a simple word on an empty board."""
         rack = [Tile('C', 3), Tile('A', 1), Tile('R', 1), Tile('T', 1), Tile('X', 8)]
-        moves = self.gaddag.find_moves(rack, self.board)
+        moves = self.gaddag.find_moves(rack, self.board, max_moves=1000)
         
         found_words = {move[0] for move in moves}
         self.assertIn('CAT', found_words)


### PR DESCRIPTION
## Summary
- Add `max_moves` parameter to `Gaddag.find_moves` and related helpers to cap recursive search
- Integrate new limit into POMCTS via `MAX_LEGAL_MOVES` constant
- Update unit test to accommodate new API

## Testing
- `python test_scrabble.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae12ecd12883248bcafd27a9a30384